### PR TITLE
feat: check for gstreamer or pipewire libraries before setting them

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -129,15 +129,15 @@ append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libunity"
 append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pulseaudio"
 
 # Tell Pipewire where to find its configuration and plugins
-export PIPEWIRE_CONFIG_DIR="$SNAP_DESKTOP_RUNTIME/usr/share/pipewire"
-export PIPEWIRE_MODULE_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pipewire-0.3"
-export SPA_PLUGIN_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/spa-0.2"
+export PIPEWIRE_CONFIG_DIR=${PIPEWIRE_CONFIG_DIR:-"$SNAP_DESKTOP_RUNTIME/usr/share/pipewire"}
+export PIPEWIRE_MODULE_DIR=${PIPEWIRE_MODULE_DIR:-"$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pipewire-0.3"}
+export SPA_PLUGIN_DIR=${SPA_PLUGIN_DIR:-"$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/spa-0.2"}
 
 # Tell GStreamer where to find its plugins
-export GST_PLUGIN_PATH="$SNAP/usr/lib/$ARCH/gstreamer-1.0"
-export GST_PLUGIN_SYSTEM_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer-1.0"
+export GST_PLUGIN_PATH=${GST_PLUGIN_PATH:-"$SNAP/usr/lib/$ARCH/gstreamer-1.0"}
+export GST_PLUGIN_SYSTEM_PATH=${GST_PLUGIN_SYSTEM_PATH:-"$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer-1.0"}
 # gst plugin scanner doesn't install in the correct path: https://github.com/ubuntu/snapcraft-desktop-helpers/issues/43
-export GST_PLUGIN_SCANNER="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+export GST_PLUGIN_SCANNER=${GST_PLUGIN_SCANNER:-"$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"}
 
 # XDG Config
 prepend_dir XDG_CONFIG_DIRS "$SNAP_DESKTOP_RUNTIME/etc/xdg"


### PR DESCRIPTION
This PR allows snaps to use their own set of pipewire or gstreamer libraries.