### PR TITLE
Update caches when desktop extension is updated

### DIFF
--- a/common/init
+++ b/common/init
@@ -80,3 +80,14 @@ if ! grep -qs "^\s*confinement:\s*classic\s*" "$SNAP/meta/snap.yaml"; then
     export LD_PRELOAD="$LD_PRELOAD:$SNAP/gnome-platform/\$LIB/bindtextdomain.so"
   fi
 fi
+
+# Check if the desktop runtime has been updated
+
+RUNTIME_LAST_DATE="$SNAP_USER_COMMON/.cache/desktop-runtime-date"
+
+if [ ! -f "$RUNTIME_LAST_DATE" -o \
+       "$SNAP_DESKTOP_RUNTIME" -nt "$RUNTIME_LAST_DATE" -o \
+       "$SNAP_DESKTOP_RUNTIME" -ot "$RUNTIME_LAST_DATE" ]; then
+  needs_update=true
+  touch -r "$SNAP_DESKTOP_RUNTIME" "$RUNTIME_LAST_DATE"
+fi


### PR DESCRIPTION
The desktop extensions (like gnome-46-2404, or the qt/kde one), do cache several paths for icons, fonts, pixbuf-loaders... all them pointing to desktop extension files.

Unfortunately, these caches are refreshed only when the application snap is updated, but not if the desktop extension snap is updated. This can result in broken snaps after updating gnome extension, for example, due to several cached files changing their name or their location.

An example is the recent update of librsvg from 2.58.1 to 2.59.1: it changed the name of the gdk-pixbuf-loader library for SVG files from libpixbufloader-svg.so to libpixbufloader_svg.so. But since the cached data for the pixbuf loaders still expected the old name, the net result was that the snaps using SVG icons would fail to paint them, showing instead the "broken" icon.

This PR fixes this by checking the build date of the desktop runtime extension and comparing it with the last one stored the previous time the app was launched, and if they differ, it forces an update of the cached data.

The big advantage of this approach is that it doesn't require to update any snap, with the exception of the Gnome-XX and other extensions themselves: once they get this patch, any snap that use them will automagically update their caches during the next launch when the extension is updated.