### PR TITLE
Ensure the .cache folder exists

### DIFF
--- a/common/init
+++ b/common/init
@@ -83,11 +83,13 @@ fi
 
 # Check if the desktop runtime has been updated
 
-RUNTIME_LAST_DATE="$SNAP_USER_COMMON/.cache/desktop-runtime-date"
+USER_CACHE_FOLDER="$SNAP_USER_COMMON/.cache"
+RUNTIME_LAST_DATE="$USER_CACHE_FOLDER/desktop-runtime-date"
 
 if [ ! -f "$RUNTIME_LAST_DATE" -o \
        "$SNAP_DESKTOP_RUNTIME" -nt "$RUNTIME_LAST_DATE" -o \
        "$SNAP_DESKTOP_RUNTIME" -ot "$RUNTIME_LAST_DATE" ]; then
   needs_update=true
+  mkdir -p "$USER_CACHE_FOLDER"
   touch -r "$SNAP_DESKTOP_RUNTIME" "$RUNTIME_LAST_DATE"
 fi


### PR DESCRIPTION
The last patch added a check to ensure that the runtime data (like icons and fonts) are up-to-date after the desktop runtime has been updated. Unfortunately, the code presumes that the .cache folder already exists, which is not always the case.

This patch fixes this.

Fix https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2097403